### PR TITLE
Add option that draws shadow behind artboards

### DIFF
--- a/Quick Presentation.sketchplugin/Contents/Sketch/config.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/config.js
@@ -1,11 +1,11 @@
 var Config = {
-    docSize : 1,                // Specify 1 for 1x, 2 for 2x, etc. for what size you're designing at.
-    margin : 20,                // Sets the margin around your presentation.
+    docSize : 1,                        // Specify 1 for 1x, 2 for 2x, etc. for what size you're designing at.
+    margin : 20,                        // Sets the margin in pixels around your presentation.
     artboardColor : '#E6E6E6',
     artboardTitle : 'example',
-    //titleAboveScreens : 'ScreenTitle',
-    fontType : 'Helvetica',     // Font type for titles above artboards.
-    fontColor : '#2F5060',      // Font color for titles above artboards.
-    fontSize : 18,              // Base font size for titles. This will double when docSize set to 2.
-    createArtboardShadows : true,       // Draw a shape with shadow behind each artboard
+    //titleAboveScreens : 'ScreenTitle',// Use this text above all artboards
+    fontType : 'Helvetica',             // Font type for titles above artboards.
+    fontColor : '#2F5060',              // Font color for titles above artboards.
+    fontSize : 18,                      // Base font size in pixels for titles. This will double when docSize set to 2.
+    createArtboardShadows : true,       // Draw a shape with shadow behind each artboard (true or false)
 };

--- a/Quick Presentation.sketchplugin/Contents/Sketch/config.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/config.js
@@ -7,5 +7,5 @@ var Config = {
     fontType : 'Helvetica',             // Font type for titles above artboards.
     fontColor : '#2F5060',              // Font color for titles above artboards.
     fontSize : 18,                      // Base font size in pixels for titles. This will double when docSize set to 2.
-    createArtboardShadows : true,       // Draw a shape with shadow behind each artboard (true or false)
+    createArtboardShadows : false,       // Draw a shape with shadow behind each artboard (true or false)
 };

--- a/Quick Presentation.sketchplugin/Contents/Sketch/config.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/config.js
@@ -5,4 +5,5 @@ var docSize = 1, // Specify 1 for 1x, 2 for 2x, etc. for what size you're design
     //titleAboveScreens = 'ScreenTitle',
     fontType = 'Helvetica', // Font type for titles above artboards.
     fontColor = '#2F5060', // Font color for titles above artboards.
-    fontSize = 18; // Base font size for titles. This will double when docSize set to 2.
+    fontSize = 18, // Base font size for titles. This will double when docSize set to 2.
+    createShadows = true;

--- a/Quick Presentation.sketchplugin/Contents/Sketch/config.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/config.js
@@ -1,9 +1,11 @@
-var docSize = 1, // Specify 1 for 1x, 2 for 2x, etc. for what size you're designing at.
-    margin = 20, // Sets the margin around your presentation.
-    artboardColor = '#E6E6E6',
-    artboardTitle = 'example',
-    //titleAboveScreens = 'ScreenTitle',
-    fontType = 'Helvetica', // Font type for titles above artboards.
-    fontColor = '#2F5060', // Font color for titles above artboards.
-    fontSize = 18, // Base font size for titles. This will double when docSize set to 2.
-    createShadows = true;
+var Config = {
+    docSize : 1,                // Specify 1 for 1x, 2 for 2x, etc. for what size you're designing at.
+    margin : 20,                // Sets the margin around your presentation.
+    artboardColor : '#E6E6E6',
+    artboardTitle : 'example',
+    //titleAboveScreens : 'ScreenTitle',
+    fontType : 'Helvetica',     // Font type for titles above artboards.
+    fontColor : '#2F5060',      // Font color for titles above artboards.
+    fontSize : 18,              // Base font size for titles. This will double when docSize set to 2.
+    createArtboardShadows : true,       // Draw a shape with shadow behind each artboard
+};

--- a/Quick Presentation.sketchplugin/Contents/Sketch/create-presentation.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/create-presentation.js
@@ -9,7 +9,20 @@ function createwithoutTitles(context) {
     app.displayDialog_withTitle("Select at least two artboards to use this plugin.", "Nothing is selected.")
     return false;
   }
-  createArtboard(context);
+  var artboard = createArtboard(context);
+  frame = artboard.frame();
+
+  if( Config.createArtboardShadows ){
+    for (var i = 0; i < selectedCount; i++) {
+      var shadowX = selection.objectAtIndex(i).frame().minX() - frame.minX(),
+          shadowY = selection.objectAtIndex(i).frame().minY() - frame.minY(),
+          shadowW = selection.objectAtIndex(i).frame().width(),
+          shadowH = selection.objectAtIndex(i).frame().height(),
+          artboardThis = selection.objectAtIndex(i),
+          artboardName = [artboardThis name];
+      createShadow(context, shadowX, shadowY, shadowW, shadowH, artboard, artboardName);
+    }
+  }
 };
 
 function createwithTitles(context) {
@@ -18,20 +31,21 @@ function createwithTitles(context) {
   var selectedCount = selection.count();
   if ( selectedCount < 2 ) {
     app.displayDialog_withTitle("Select at least two artboards to use this plugin.", "Nothing is selected.")
+    return false;
   }
   var artboard = createArtboard(context)
-  frame = artboard.frame()
+  frame = artboard.frame();
 
   // Add extra height to artboard for text
-  var addToArtboard = (fontSize+3)*docSize; // Specifies extra space to add text
+  var addToArtboard = (Config.fontSize+3)*Config.docSize; // Specifies extra space to add text
   frame.setWidth((frame.width()))
   frame.setHeight(frame.height()+addToArtboard))
   frame.setY((frame.minY()-addToArtboard))
 
-  // Add Text layers
+  // Add layers
   for (var i = 0; i < selectedCount; i++) {
     var textX = selection.objectAtIndex(i).frame().minX() - frame.minX(),
-        textY = selection.objectAtIndex(i).frame().minY() - frame.minY() - ((fontSize*docSize) + 12),
+        textY = selection.objectAtIndex(i).frame().minY() - frame.minY() - ((Config.fontSize*Config.docSize) + 12),
         shadowX = selection.objectAtIndex(i).frame().minX() - frame.minX(),
         shadowY = selection.objectAtIndex(i).frame().minY() - frame.minY(),
         shadowW = selection.objectAtIndex(i).frame().width(),
@@ -41,13 +55,13 @@ function createwithTitles(context) {
     } else {
       var artboardThis = selection.objectAtIndex(i)
       var artboardName = [artboardThis name];
-      var maxLength = selection.objectAtIndex(i).frame().width  () / (11.4*docSize);
+      var maxLength = selection.objectAtIndex(i).frame().width  () / (11.4*Config.docSize);
       if (artboardName.length() > maxLength){
         artboardName = artboardName.substring(0,maxLength);
         artboardName += '…';
       }
     }
-    if(createShadows){
+    if( Config.createArtboardShadows ){
       createShadow(context, shadowX, shadowY, shadowW, shadowH, artboard, artboardName);
     }
     createText(context, textX, textY, artboard, artboardName);
@@ -58,9 +72,9 @@ function createText(context, x, y, artboard, artboardName){
   var doc = context.document;
   var textLayer = MSTextLayer.new();
   textLayer.setStringValue(artboardName);
-  textLayer.setFontSize(fontSize*docSize);
-  textLayer.setFontPostscriptName(fontType);
-  textLayer.setTextColor(MSColor.colorWithSVGString(fontColor))
+  textLayer.setFontSize( Config.fontSize * Config.docSize);
+  textLayer.setFontPostscriptName( Config.fontType );
+  textLayer.setTextColor(MSColor.colorWithSVGString( Config.fontColor ))
   textLayer.frame().setX(x);
   textLayer.frame().setY(y);
   textLayer.setTextBehaviour(1);
@@ -72,10 +86,12 @@ function createText(context, x, y, artboard, artboardName){
 function createShadow(context, x, y, w, h, artboard, artboardName){
   var rect = MSRectangleShape.alloc().init();
   rect.frame = MSRect.rectWithRect(NSMakeRect(x, y, w, h));
-  rect.setName(artboardName + ' bg');
+  rect.setName(artboardName + ' shadow');
 
   // Draw rectangle behind artboard
   var shapeGroup = MSShapeGroup.shapeWithPath(rect);
+
+  // TODO: make rectangle and shadow properties configurable too
 
   // Add white fill to rectangle
   var white = MSColor.colorWithSVGString("#ffffff");

--- a/Quick Presentation.sketchplugin/Contents/Sketch/create-presentation.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/create-presentation.js
@@ -58,5 +58,6 @@ function createText(context, x, y, artboard, artboardName){
   textLayer.frame().setY(y);
   textLayer.setTextBehaviour(1);
   textLayer.setTextBehaviour(0);
+  textLayer.setName(artboardName + ' label');
   var newText = artboard.addLayers_([textLayer]);
 }

--- a/Quick Presentation.sketchplugin/Contents/Sketch/create-presentation.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/create-presentation.js
@@ -30,8 +30,12 @@ function createwithTitles(context) {
 
   // Add Text layers
   for (var i = 0; i < selectedCount; i++) {
-    var x = selection.objectAtIndex(i).frame().minX() - frame.minX(),
-    y = selection.objectAtIndex(i).frame().minY() - frame.minY() - ((fontSize*docSize) + 12);
+    var textX = selection.objectAtIndex(i).frame().minX() - frame.minX(),
+        textY = selection.objectAtIndex(i).frame().minY() - frame.minY() - ((fontSize*docSize) + 12),
+        shadowX = selection.objectAtIndex(i).frame().minX() - frame.minX(),
+        shadowY = selection.objectAtIndex(i).frame().minY() - frame.minY(),
+        shadowW = selection.objectAtIndex(i).frame().width(),
+        shadowH = selection.objectAtIndex(i).frame().height();
     if (typeof titleAboveScreens !== 'undefined') {
       var artboardName = titleAboveScreens;
     } else {
@@ -43,7 +47,10 @@ function createwithTitles(context) {
         artboardName += '…';
       }
     }
-    createText(context, x, y, artboard, artboardName);
+    if(createShadows){
+      createShadow(context, shadowX, shadowY, shadowW, shadowH, artboard, artboardName);
+    }
+    createText(context, textX, textY, artboard, artboardName);
   }
 };
 
@@ -60,4 +67,28 @@ function createText(context, x, y, artboard, artboardName){
   textLayer.setTextBehaviour(0);
   textLayer.setName(artboardName + ' label');
   var newText = artboard.addLayers_([textLayer]);
+}
+
+function createShadow(context, x, y, w, h, artboard, artboardName){
+  var rect = MSRectangleShape.alloc().init();
+  rect.frame = MSRect.rectWithRect(NSMakeRect(x, y, w, h));
+  rect.setName(artboardName + ' bg');
+
+  // Draw rectangle behind artboard
+  var shapeGroup = MSShapeGroup.shapeWithPath(rect);
+
+  // Add white fill to rectangle
+  var white = MSColor.colorWithSVGString("#ffffff");
+  shapeGroup.style().addStylePartOfType(0);
+  shapeGroup.style().fills().firstObject().setColor(white);
+
+  // Add subtle shadow to rectangle
+  shapeGroup.style().addStylePartOfType(2);
+  var black = MSColor.colorWithSVGString("#000000");
+  black.alpha = 0.2;
+  shapeGroup.style().shadows().firstObject().setColor(black);
+  shapeGroup.style().shadows().firstObject().setOffsetY(1);
+  shapeGroup.style().shadows().firstObject().setBlurRadius(2);
+
+  artboard.addLayers([shapeGroup]);
 }

--- a/Quick Presentation.sketchplugin/Contents/Sketch/manifest.json
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/manifest.json
@@ -23,12 +23,20 @@
       "shortcut" : "",
       "name" : "Without Titles",
       "identifier" : "withoutTitles"
+    },
+    {
+      "script" : "create-presentation.js",
+      "handler" : "createwithTitles",
+      "shortcut" : "",
+      "name" : "With Titles & Artboard Shadows",
+      "identifier" : "withTitlesAndShadows"
     }
   ],
   "menu": {
     "items": [
       "withTitles",
-      "withoutTitles"
+      "withoutTitles",
+      "withTitlesAndShadows",
     ],
     "title" : "Quick Presentation"
   }

--- a/Quick Presentation.sketchplugin/Contents/Sketch/manifest.json
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/manifest.json
@@ -23,13 +23,6 @@
       "shortcut" : "",
       "name" : "Without Titles",
       "identifier" : "withoutTitles"
-    },
-    {
-      "script" : "create-presentation.js",
-      "handler" : "createwithTitles",
-      "shortcut" : "",
-      "name" : "With Titles & Artboard Shadows",
-      "identifier" : "withTitlesAndShadows"
     }
   ],
   "menu": {

--- a/Quick Presentation.sketchplugin/Contents/Sketch/util.js
+++ b/Quick Presentation.sketchplugin/Contents/Sketch/util.js
@@ -25,21 +25,21 @@ function createArtboard(context) {
     }
   }
 
-  var totalwidth=maxX-minX; // Last artboards X most point to the first artboard's minimum X most point
-  var totalheight=maxY-minY;
+  var totalwidth = maxX-minX; // Last artboards X most point to the first artboard's minimum X most point
+  var totalheight = maxY-minY;
 
-  artboard = MSArtboardGroup.new()
-  frame = artboard.frame()
-  frame.setWidth(totalwidth + (margin*2))
-  frame.setHeight(totalheight + (margin*2))
-  frame.setX(minX-margin)
-  frame.setY(minY-margin)
-  artboard.setName(artboardTitle)
+  artboard = MSArtboardGroup.new();
+  frame = artboard.frame();
+  frame.setWidth( totalwidth + ( Config.margin * 2) );
+  frame.setHeight( totalheight + ( Config.margin * 2) );
+  frame.setX( minX - Config.margin );
+  frame.setY( minY - Config.margin );
+  artboard.setName( Config.artboardTitle );
   artboard.setHasBackgroundColor(true);
-  artboard.backgroundColor=MSColor.colorWithSVGString(artboardColor)
+  artboard.backgroundColor=MSColor.colorWithSVGString( Config.artboardColor );
   artboard.setConstrainProportions(false);
-  var newArtboard = doc.currentPage().addLayers([artboard])
-  [[artboard exportOptions] addExportFormat]
+  var newArtboard = doc.currentPage().addLayers([artboard]);
+  [[artboard exportOptions] addExportFormat];
 
   artboard.select_byExpandingSelection(true, false);
   actionWithType("MSMoveToBackAction",context).moveToBack(null);

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To edit: Right-click 'Quick Presentation.sketchplugin' → Select 'Show Package 
 - **fontType**: Font type for titles above artboards. Default: Helvetica
 - **fontColor**: Font color for titles above artboards. Default: #2F5060
 - **fontSize**: Base font size for titles. This will double when docSize set to 2. Default: 18
+- **createArtboardShadows**: Draw a shape with shadow behind each artboard. Default: false
 
 ## Feature requests and feedback
 Ping me on [twitter](http://twitter.com/timothywhalin) or follow for updates.


### PR DESCRIPTION
Hi,

Thanks for the great Sketch plugin. It was 99% what I was looking for :-). 
I also needed the option to have shadows behind the artboards for the export. So that is what I added. And while I was at it, I also improved the name of your generated title layers. 
And then I thought, what the heck, lets make it a pull request.

The git history is a bit messy, but I hope you like the feature too.

Best regards!
Bram
